### PR TITLE
MP/4.Add username information to SignUp and Login

### DIFF
--- a/__tests__/LoadingScreen-test.js
+++ b/__tests__/LoadingScreen-test.js
@@ -1,9 +1,16 @@
 import 'react-native'
 import React from 'react'
 import LoadingScreen from '../src/screens/LoadingScreen'
-
+import * as firebase from 'firebase'
+import firebaseConfig from '~/configs/firebase'
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer'
+
+beforeAll(() => {
+  if (firebase.apps.length === 0) {
+    firebase.initializeApp(firebaseConfig)
+  }
+})
 
 it('renders correctly', () => {
   renderer.create(<LoadingScreen />)

--- a/__tests__/firebaseDatabase-test.js
+++ b/__tests__/firebaseDatabase-test.js
@@ -1,0 +1,75 @@
+import 'react-native'
+import * as firebase from 'firebase'
+import firebaseConfig from '~/configs/firebase'
+import DatabaseService from '~/databaseService'
+
+// careful, all these test involve real transactions in a database so I will put a describe clause to facilitate skipping
+
+const username = 'user'
+const email = 'user@test.com'
+
+describe.skip('test that involve real database transactions', () => {
+  beforeAll(() => {
+    if (firebase.apps.length === 0) {
+      firebase.initializeApp(firebaseConfig)
+    }
+  })
+
+  beforeEach(async () => {
+    await firebase.firestore().doc('testing/user').set({
+      email,
+      username
+    })
+  })
+
+  test('set on database', async () => {
+    await DatabaseService.set('testing/another', {
+      email: 'another@test.com',
+      username: 'another'
+    })
+    const databaseSnapshot = await firebase.firestore().doc('testing/another').get()
+    const values = databaseSnapshot.data()
+    expect(values).toEqual({
+      email: 'another@test.com',
+      username: 'another'
+    })
+  })
+
+  test('get to the database', async () => {
+    const values = await DatabaseService.get('testing/user')
+    expect(values).toEqual({
+      email: 'user@test.com',
+      username: 'user'
+    })
+  })
+
+  test('get email from username', async () => {
+    const email = await DatabaseService.queryEmailFromUsername('user', 'testing')
+    expect(email).toBe('user@test.com')
+  })
+
+  test('get email from non-existant username', async () => {
+    const email = await DatabaseService.queryEmailFromUsername('notUser', 'testing')
+    expect(email).toBeUndefined()
+  })
+
+  test('username already in user', async () => {
+    expect(await DatabaseService.usernameAlreadyInUse('user', 'testing')).toBeTruthy()
+  })
+
+  test('update tests', async () => {
+    const data = {
+      email: '2@test.com',
+      username: 'user'
+    }
+
+    await DatabaseService.update('testing/user', data)
+
+    const databaseSnapshot = await firebase.firestore().doc('testing/user').get()
+    const values = databaseSnapshot.data()
+    expect(values).toEqual({
+      email: '2@test.com',
+      username: 'user'
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "react-native": "0.61.2",
     "react-native-dotenv": "^0.2.0",
     "react-native-gesture-handler": "^1.4.1",
+    "react-native-reanimated": "^1.3.0",
     "react-navigation": "^4.0.10",
     "react-navigation-stack": "^1.9.4",
+    "react-navigation-tabs": "^2.5.6",
     "yup": "^0.27.0"
   },
   "devDependencies": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,20 +1,57 @@
+import fixtimerbug from '~/bugFixes/fixtimerbug' // this is just an import to load the fix
 import React from 'react'
 import { createAppContainer, createSwitchNavigator } from 'react-navigation'
+import { createBottomTabNavigator } from 'react-navigation-tabs'
+import * as firebase from 'firebase'
+import 'firebase/firestore'
+import firebaseConfig from './configs/firebase'
 import NavigationService from './navigationService'
 import SignUp from './screens/authentication/SignUp'
 import Login from './screens/authentication/Login'
-import Home from './screens/Home'
+import Home from './screens/MainApp/Home'
 import LoadingScreen from './screens/LoadingScreen'
-import * as firebase from 'firebase'
-import firebaseConfig from './configs/firebase'
+import DiagnoseRequest from './screens/MainApp/DiagnoseRequest'
+import DiagnoseResponse from './screens/MainApp/DiagnoseResponse'
+import Settings from './screens/MainApp/Settings'
 
 if (firebase.apps.length === 0) {
   firebase.initializeApp(firebaseConfig)
 }
 
+const MainApp = createBottomTabNavigator({
+  Home: {
+    screen: Home,
+    navigationOptions: {
+      headerTitle: 'Home',
+      tabBarLabel: 'Principal'
+    }
+  },
+  DiagnoseRequest: {
+    screen: DiagnoseRequest,
+    navigationOptions: {
+      headerTitle: 'DiagnoseRequest',
+      tabBarLabel: 'Diagnosticar'
+    }
+  },
+  DiagnoseResponse: {
+    screen: DiagnoseResponse,
+    navigationOptions: {
+      headerTitle: 'DiagnoseResponse',
+      tabBarLabel: 'Diagnósticos'
+    }
+  },
+  Settings: {
+    screen: Settings,
+    navigationOptions: {
+      headerTitle: 'Settings',
+      tabBarLabel: 'Opciones'
+    }
+  }
+})
+
 const MainNavigator = createSwitchNavigator({
   LoadingScreen: { screen: LoadingScreen },
-  Home: { screen: Home },
+  MainApp: { screen: MainApp },
   SignUp: { screen: SignUp },
   Login: { screen: Login }
 })
@@ -28,4 +65,5 @@ const App = () => (
     }}
   />
 )
+
 export default App

--- a/src/bugFixes/fixtimerbug/index.js
+++ b/src/bugFixes/fixtimerbug/index.js
@@ -1,0 +1,45 @@
+/*
+This is the solution that works in the official issue on Github about this problem. Without this, a warning regarding long timers appears, it's a bug between firebase and
+react-native.
+https://github.com/facebook/react-native/issues/12981#issuecomment-499827072
+*/
+
+import { Platform, InteractionManager } from 'react-native'
+const _setTimeout = global.setTimeout
+const _clearTimeout = global.clearTimeout
+const MAX_TIMER_DURATION_MS = 60 * 1000
+if (Platform.OS === 'android') {
+  const timerFix = {}
+  const runTask = (id, fn, ttl, args) => {
+    const waitingTime = ttl - Date.now()
+    if (waitingTime <= 1) {
+      InteractionManager.runAfterInteractions(() => {
+        if (!timerFix[id]) {
+          return
+        }
+        delete timerFix[id]
+        fn(...args)
+      })
+      return
+    }
+    const afterTime = Math.min(waitingTime, MAX_TIMER_DURATION_MS)
+    timerFix[id] = _setTimeout(() => runTask(id, fn, ttl, args), afterTime)
+  }
+  global.setTimeout = (fn, time, ...args) => {
+    if (MAX_TIMER_DURATION_MS < time) {
+      const ttl = Date.now() + time
+      const id = '_lt_' + Object.keys(timerFix).length
+      runTask(id, fn, ttl, args)
+      return id
+    }
+    return _setTimeout(fn, time, ...args)
+  }
+  global.clearTimeout = id => {
+    if (typeof id === 'string' && id.startsWith('_lt_')) {
+      _clearTimeout(timerFix[id])
+      delete timerFix[id]
+      return
+    }
+    _clearTimeout(id)
+  }
+}

--- a/src/configs/firebase/index.js
+++ b/src/configs/firebase/index.js
@@ -1,8 +1,10 @@
-import { API_KEY, AUTH_DOMAIN } from 'react-native-dotenv'
+import { API_KEY, AUTH_DOMAIN, DATABASE_URL, PROJECT_ID } from 'react-native-dotenv'
 
 const firebaseConfig = {
   apiKey: API_KEY,
-  authDomain: AUTH_DOMAIN
+  authDomain: AUTH_DOMAIN,
+  databaseURL: DATABASE_URL,
+  projectId: PROJECT_ID
 }
 
 export default firebaseConfig

--- a/src/databaseService/index.js
+++ b/src/databaseService/index.js
@@ -1,0 +1,57 @@
+import 'react-native'
+import * as firebase from 'firebase'
+
+const set = async (docPath, data) => {
+  try {
+    await firebase.firestore().doc(docPath).set(data)
+  } catch (error) {
+    console.log(error.message)
+  }
+}
+
+const get = async (docPath) => {
+  try {
+    const databaseSnapshot = await firebase.firestore().doc(docPath).get()
+
+    return databaseSnapshot.data()
+  } catch (error) {
+    console.log(error.message)
+  }
+}
+
+const update = async (docPath, data) => {
+  try {
+    await firebase.firestore().doc(docPath).update(data)
+  } catch (error) {
+    console.log(error.message)
+  }
+}
+
+const queryEmailFromUsername = async (username, collectionPath = 'users') => {
+  try {
+    const querySnapshot = await firebase.firestore().collection(collectionPath).where('username', '==', username).get()
+    if (hasDocuments(querySnapshot)) {
+      const json = getFirstDocumentDataFromQuerySnapshot(querySnapshot)
+      return json && json.email
+    }
+  } catch (error) {
+    console.log(error.message)
+  }
+}
+
+const getFirstDocumentDataFromQuerySnapshot = (querySnapshot) => querySnapshot.docs[0].data()
+const hasDocuments = (querySnapshot) => querySnapshot.size > 0
+
+const usernameAlreadyInUse = async (username, collectionPath = 'users') => {
+  const email = await queryEmailFromUsername(username, collectionPath)
+
+  return email !== undefined
+}
+
+export default {
+  set,
+  get,
+  update,
+  usernameAlreadyInUse,
+  queryEmailFromUsername
+}

--- a/src/screens/LoadingScreen/index.js
+++ b/src/screens/LoadingScreen/index.js
@@ -6,7 +6,7 @@ import * as firebase from 'firebase'
 const checkIfLoggedIn = () => {
   firebase.auth().onAuthStateChanged(user => {
     if (user) {
-      NavigationService.navigate('Home')
+      NavigationService.navigate('MainApp')
     } else {
       NavigationService.navigate('Login')
     }

--- a/src/screens/MainApp/DiagnoseRequest/index.js
+++ b/src/screens/MainApp/DiagnoseRequest/index.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Text, View } from 'react-native'
+
+const DiagnoseRequest = () => {
+  return (
+    <View>
+      <Text>
+      DiagnoseRequest
+      </Text>
+    </View>
+  )
+}
+
+export default DiagnoseRequest

--- a/src/screens/MainApp/DiagnoseResponse/index.js
+++ b/src/screens/MainApp/DiagnoseResponse/index.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Text, View } from 'react-native'
+
+const DiagnoseResponse = () => {
+  return (
+    <View>
+      <Text>
+      DiagnoseResponse
+      </Text>
+    </View>
+  )
+}
+
+export default DiagnoseResponse

--- a/src/screens/MainApp/Home/index.js
+++ b/src/screens/MainApp/Home/index.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import { Text, View, Button } from 'react-native'
-import NavigationService from '../../navigationService'
+import NavigationService from '~/navigationService'
 import * as firebase from 'firebase'
 
 const LogOut = async () => {
   try {
     await firebase.auth().signOut()
-    NavigationService.navigate('SignUp')
+    NavigationService.navigate('Login')
   } catch (error) {
     console.log(error.message)
   }

--- a/src/screens/MainApp/Settings/index.js
+++ b/src/screens/MainApp/Settings/index.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Text, View } from 'react-native'
+
+const Settings = () => {
+  return (
+    <View>
+      <Text>
+      Settings
+      </Text>
+    </View>
+  )
+}
+
+export default Settings

--- a/src/screens/authentication/AuthenticatingIndicator/index.js
+++ b/src/screens/authentication/AuthenticatingIndicator/index.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { ActivityIndicator } from 'react-native'
+
+const AuthenticatingIndicator = ({ authenticating }) => (
+  authenticating && <ActivityIndicator />
+)
+
+export default AuthenticatingIndicator

--- a/src/screens/authentication/Background/index.js
+++ b/src/screens/authentication/Background/index.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { ImageBackground } from 'react-native'
+import styles from '~/screens/authentication/styles'
+
+const Background = ({ children }) => (
+  <ImageBackground
+    style={styles.backgroundImage}
+    source={require('~/screens/authentication/resources/background.jpg')}
+  >
+    {children}
+  </ImageBackground>
+)
+
+export default Background

--- a/src/screens/authentication/Login/LoginForm/index.js
+++ b/src/screens/authentication/Login/LoginForm/index.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import { KeyboardAvoidingView, TextInput, TouchableHighlight } from 'react-native'
+import { Formik } from 'formik'
+import AppText from '~/helpers/AppText'
+import AuthenticatingIndicator from '~/screens/authentication/AuthenticatingIndicator'
+import styles from './styles'
+
+const Error = ({ error }) => (
+  error && <AppText style={styles.loginError}>
+  Las credenciales ingresadas no coinciden con nuestros registros.
+  </AppText>
+)
+
+const LoginButton = ({ onPress }) => (
+  <TouchableHighlight
+    style={styles.loginButton}
+    onPress={onPress}
+  >
+    <AppText style={styles.loginText}>
+       Ingresar
+    </AppText>
+  </TouchableHighlight>
+)
+
+const LoginForm = ({ initialValues, handleSubmit, error, authenticating }) => (
+  <Formik
+    initialValues={initialValues}
+    onSubmit={handleSubmit}
+  >
+    {formikProps => (
+      <KeyboardAvoidingView style={styles.loginForm}>
+        <TextInput
+          style={styles.label}
+          placeholder='Nombre de usuario o email'
+          placeholderTextColor='white'
+          onChangeText={formikProps.handleChange('account')}
+          value={formikProps.values.account}
+        />
+        <TextInput
+          style={styles.label}
+          placeholder='contraseña'
+          placeholderTextColor='white'
+          secureTextEntry
+          onChangeText={formikProps.handleChange('password')}
+          value={formikProps.values.password}
+        />
+        <Error error={error} />
+        <AuthenticatingIndicator authenticating={authenticating} />
+        <LoginButton onPress={formikProps.handleSubmit} />
+      </KeyboardAvoidingView>
+    )}
+  </Formik>
+)
+
+export default LoginForm

--- a/src/screens/authentication/Login/LoginForm/styles.js
+++ b/src/screens/authentication/Login/LoginForm/styles.js
@@ -1,0 +1,36 @@
+import { StyleSheet } from 'react-native'
+
+const styles = StyleSheet.create({
+  loginError: {
+    textAlign: 'center',
+    color: 'white'
+  },
+  loginForm: {
+    width: '75%',
+    margin: '25%'
+  },
+  loginButton: {
+    backgroundColor: 'rgba(92, 254, 78, 0.71)',
+    borderRadius: 40,
+    margin: 30,
+    padding: 10,
+    alignSelf: 'center'
+  },
+  loginText: {
+    color: 'white'
+  },
+  errorMessage: {
+    paddingLeft: 20,
+    color: 'white'
+  },
+  label: {
+    margin: 13,
+    paddingLeft: 15,
+    backgroundColor: 'rgba(254,93,78, 0.8)',
+    color: 'white',
+    textDecorationLine: 'none',
+    borderRadius: 40
+  }
+})
+
+export default styles

--- a/src/screens/authentication/Login/LoginHeader/index.js
+++ b/src/screens/authentication/Login/LoginHeader/index.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Image } from 'react-native'
+import AppText from '~/helpers/AppText'
+import styles from './styles'
+
+const LoginHeader = () => (
+  <>
+    <Image
+      style={styles.loginImage}
+      source={require('~/screens/authentication/resources/whiteKey.png')}
+    />
+    <AppText style={styles.loginText}> Iniciar Sesión</AppText>
+  </>
+)
+
+export default LoginHeader

--- a/src/screens/authentication/Login/LoginHeader/styles.js
+++ b/src/screens/authentication/Login/LoginHeader/styles.js
@@ -1,0 +1,18 @@
+import { StyleSheet } from 'react-native'
+
+const styles = StyleSheet.create({
+  loginImage: {
+    width: 163,
+    height: 163,
+    top: '10%',
+    right: 10
+  },
+  loginText: {
+    color: 'white',
+    fontSize: 18,
+    top: '15%',
+    right: '25%'
+  }
+})
+
+export default styles

--- a/src/screens/authentication/Login/NoAccountLink/index.js
+++ b/src/screens/authentication/Login/NoAccountLink/index.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Text } from 'react-native'
+import AppText from '~/helpers/AppText'
+import NavigationService from '~/navigationService'
+import styles from './styles'
+
+const NoAccountLink = () => (
+  <AppText style={styles.noAccountText}>No tenes una cuenta? {' '}
+    <Text
+      onPress={() => NavigationService.navigate('SignUp')}
+      style={styles.underlineText}>
+           Registrate
+    </Text>
+  </AppText>
+)
+
+export default NoAccountLink

--- a/src/screens/authentication/Login/NoAccountLink/styles.js
+++ b/src/screens/authentication/Login/NoAccountLink/styles.js
@@ -1,0 +1,13 @@
+import { StyleSheet } from 'react-native'
+
+const styles = StyleSheet.create({
+  noAccountText: {
+    color: 'white',
+    bottom: '10%'
+  },
+  underlineText: {
+    textDecorationLine: 'underline'
+  }
+})
+
+export default styles

--- a/src/screens/authentication/SignUp/AccountLink/index.js
+++ b/src/screens/authentication/SignUp/AccountLink/index.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Text } from 'react-native'
+import AppText from '~/helpers/AppText'
+import NavigationService from '~/navigationService'
+import styles from './styles'
+
+const AccountLink = () => (
+  <AppText style={styles.accountText}>Ya tenés una cuenta? {' '}
+    <Text
+      onPress={() => NavigationService.navigate('Login')}
+      style={styles.underlineText}>
+           Iniciá sesión
+    </Text>
+  </AppText>
+)
+
+export default AccountLink

--- a/src/screens/authentication/SignUp/AccountLink/styles.js
+++ b/src/screens/authentication/SignUp/AccountLink/styles.js
@@ -1,0 +1,13 @@
+import { StyleSheet } from 'react-native'
+
+const styles = StyleSheet.create({
+  accountText: {
+    color: 'white',
+    bottom: '15%'
+  },
+  underlineText: {
+    textDecorationLine: 'underline'
+  }
+})
+
+export default styles

--- a/src/screens/authentication/SignUp/SignUpForm/index.js
+++ b/src/screens/authentication/SignUp/SignUpForm/index.js
@@ -1,0 +1,72 @@
+import React from 'react'
+import { KeyboardAvoidingView, TextInput, TouchableHighlight } from 'react-native'
+import { Formik } from 'formik'
+import AppText from '~/helpers/AppText'
+import AuthenticatingIndicator from '~/screens/authentication/AuthenticatingIndicator'
+import styles from './styles'
+
+const Error = ({ error }) => (
+  error && <AppText style={styles.signUpError}>
+  Combinación de usuario, email y contraseña no aceptada.
+  </AppText>
+)
+
+const SignUpButton = ({ onPress }) => (
+  <TouchableHighlight
+    style={styles.signUpButton}
+    onPress={onPress}
+  >
+    <AppText style={styles.signUpText}>
+        Registrarme
+    </AppText>
+  </TouchableHighlight>
+)
+
+const SignUpForm = ({ initialValues, handleSubmit, schema, error, authenticating }) => (
+  <Formik
+    initialValues={initialValues}
+    onSubmit={handleSubmit}
+    validationSchema={schema}
+  >
+    {formikProps => (
+      <KeyboardAvoidingView style={styles.signUpForm}>
+        <TextInput
+          style={styles.label}
+          placeholder='Nombre de usuario'
+          placeholderTextColor='white'
+          onChangeText={formikProps.handleChange('username')}
+          value={formikProps.values.username}
+        />
+        {formikProps.touched.username && formikProps.errors.username &&
+        <AppText style={styles.errorMessage}>{formikProps.errors.username}</AppText>
+        }
+        <TextInput
+          style={styles.label}
+          placeholder='email@ejemplo.com'
+          placeholderTextColor='white'
+          onChangeText={formikProps.handleChange('email')}
+          value={formikProps.values.email}
+        />
+        {formikProps.touched.email && formikProps.errors.email &&
+        <AppText style={styles.errorMessage}>{formikProps.errors.email}</AppText>
+        }
+        <TextInput
+          style={styles.label}
+          placeholder='contraseña'
+          placeholderTextColor='white'
+          secureTextEntry
+          onChangeText={formikProps.handleChange('password')}
+          value={formikProps.values.password}
+        />
+        {formikProps.touched.password && formikProps.errors.password &&
+        <AppText style={styles.errorMessage}>{formikProps.errors.password}</AppText>
+        }
+        <Error error={error} />
+        <AuthenticatingIndicator authenticating={authenticating} />
+        <SignUpButton onPress={formikProps.handleSubmit} />
+      </KeyboardAvoidingView>
+    )}
+  </Formik>
+)
+
+export default SignUpForm

--- a/src/screens/authentication/SignUp/SignUpForm/styles.js
+++ b/src/screens/authentication/SignUp/SignUpForm/styles.js
@@ -1,0 +1,36 @@
+import { StyleSheet } from 'react-native'
+
+const styles = StyleSheet.create({
+  signUpError: {
+    textAlign: 'center',
+    color: 'white'
+  },
+  signUpForm: {
+    width: '75%',
+    margin: '25%'
+  },
+  signUpButton: {
+    backgroundColor: 'rgba(92, 254, 78, 0.71)',
+    borderRadius: 40,
+    margin: 30,
+    padding: 10,
+    alignSelf: 'center'
+  },
+  signUpText: {
+    color: 'white'
+  },
+  errorMessage: {
+    paddingLeft: 20,
+    color: 'white'
+  },
+  label: {
+    margin: 13,
+    paddingLeft: 15,
+    backgroundColor: 'rgba(254,93,78, 0.8)',
+    color: 'white',
+    textDecorationLine: 'none',
+    borderRadius: 40
+  }
+})
+
+export default styles

--- a/src/screens/authentication/SignUp/SignUpHeader/index.js
+++ b/src/screens/authentication/SignUp/SignUpHeader/index.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Image } from 'react-native'
+import AppText from '~/helpers/AppText'
+import styles from './styles'
+
+const SignUpHeader = () => (
+  <>
+    <Image
+      style={styles.signUpImage}
+      source={require('~/screens/authentication/resources/signUpIconWhite.png')}
+    />
+    <AppText style={styles.signUpText}> Crear cuenta</AppText>
+  </>
+)
+
+export default SignUpHeader

--- a/src/screens/authentication/SignUp/SignUpHeader/styles.js
+++ b/src/screens/authentication/SignUp/SignUpHeader/styles.js
@@ -1,0 +1,17 @@
+import { StyleSheet } from 'react-native'
+
+const styles = StyleSheet.create({
+  signUpImage: {
+    width: 163,
+    height: 163,
+    top: '15%'
+  },
+  signUpText: {
+    color: 'white',
+    fontSize: 18,
+    top: '15%',
+    right: '25%'
+  }
+})
+
+export default styles

--- a/src/screens/authentication/styles.js
+++ b/src/screens/authentication/styles.js
@@ -6,66 +6,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center'
   },
-  signUpForm: {
-    width: '75%',
-    margin: '25%'
-  },
-  loginForm: {
-    width: '75%',
-    margin: '25%'
-  },
-  label: {
-    margin: 13,
-    paddingLeft: 15,
-    backgroundColor: 'rgba(254,93,78, 0.8)',
-    color: 'white',
-    textDecorationLine: 'none',
-    borderRadius: 40
-  },
   backgroundImage: {
     flex: 1,
     width: null,
     height: null
   },
-  signUpButton: {
-    backgroundColor: 'rgba(92, 254, 78, 0.71)',
-    borderRadius: 40,
-    margin: 30,
-    padding: 10,
-    alignSelf: 'center'
-  },
-  loginButton: {
-    backgroundColor: 'rgba(92, 254, 78, 0.71)',
-    borderRadius: 40,
-    margin: 30,
-    padding: 10,
-    alignSelf: 'center'
-  },
   whiteText: {
     color: 'white'
-  },
-  underlineText: {
-    textDecorationLine: 'underline'
-  },
-  signUpImage: {
-    width: 163,
-    height: 163,
-    top: 57
-  },
-  loginImage: {
-    width: 163,
-    height: 163,
-    top: 57,
-    right: 10
-  },
-  haveAccount: {
-    bottom: 25
-  },
-  doesntHaveAccount: {
-    bottom: 25
-  },
-  errorMessage: {
-    paddingLeft: 20
   }
 })
 

--- a/src/screens/authentication/utils/index.js
+++ b/src/screens/authentication/utils/index.js
@@ -1,0 +1,1 @@
+export const isValidEmail = (text) => text.includes('@')


### PR DESCRIPTION
- Added a bottom tab navigator for future screens, with this change I may be able to do the screens independently (To continue working with them as separate features instead of coding on top of the previous branch, and also reduce the number of different files I change per pull). **As for now, this pull must be merged after MP/3**

- Added Username to SignUp and Login. Now we can login with the username too (and as such, at the moment, the usernames must also be unique).

- I did quite a few tests with the database as I will probably use it later and I wanted to do an abstraction, regardless of this, the code retains some verbosity. A refactoring may be useful at the end of the iteration.

**Changes after refactoring**

- **Screens are now separated into more granular components, each with their own styles. Some things could be shared, such as Background and AuthenticatingIndicator, others such as Headers and AccountLink/NoAccountLink can be abstracted but in doing so they result confusing to read.**

- **Changed database to cloud firestore (noSQL based on documents)**

- **I had an urge of abstracting firebase.auth(), firebase.firestore() and initialization into a single file for modularity. It seemed a little overkill as the firebase API is very clear to use and read and another layer could have the adversary effect, what do you think?**

- I attach some pics

![image](https://user-images.githubusercontent.com/35865469/66961862-009a4d00-f046-11e9-8392-62b1150d8236.png)

![image](https://user-images.githubusercontent.com/35865469/66961898-10b22c80-f046-11e9-8c1a-4eee634576ba.png)
