### PR TITLE
[HOTFIX.MP/5][CHANGED] changed image references to be an array

### DIFF
--- a/src/databaseService/index.js
+++ b/src/databaseService/index.js
@@ -81,6 +81,8 @@ const addDiagnoseIDToCurrentUser = async (diagnoseID, collectionPath = 'users') 
 
 export const addDiagnose = async (imageReferences, text, diagnosePath = 'diagnoses') => {
   try {
+    if (!Array.isArray(imageReferences)) imageReferences = [imageReferences]
+
     const user = AuthenticationService.getCurrentUserUID()
     const newDiagnoseData = {
       user,

--- a/src/databaseService/index.js
+++ b/src/databaseService/index.js
@@ -90,7 +90,7 @@ export const addDiagnose = async (imageReferences, text, diagnosePath = 'diagnos
       imageReferences
     }
     const newDiagnoseReference = await add(diagnosePath, newDiagnoseData)
-    await addDiagnoseIDToCurrentUser(newDiagnoseReference)
+    await addDiagnoseIDToCurrentUser(newDiagnoseReference.id)
   } catch (error) {
     throw new DatabaseError(error.message)
   }


### PR DESCRIPTION
- Changed image references to be treated as an Array, instead of string. 

- Changed add diagnose to add it's ID instead of reference. It turns out firebase is a mess to work with pure references.