### PR TITLE
[MP] Diagnose response input web interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ _env
 *.keystore
 gradle.properties
 build/
+.cache/
+dist/
 
 #All next is react-native .gitignore
 

--- a/admin-src/DiagnoseInfo/index.js
+++ b/admin-src/DiagnoseInfo/index.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export const DiagnoseInfo = ({ diagnose }) => (
+  <div>
+    <div>
+      DIAGNOSE UUID: {diagnose.id}
+    </div>
+    <div>
+      USER UUID: {diagnose.user}
+    </div>
+    <div>
+      TEXT: {diagnose.text}
+    </div>
+    {diagnose.imagesSources && diagnose.imagesSources.map((imageSource, index) => (
+      <img key={index} className='diagnose-image' src={imageSource} />
+    ))}
+  </div>
+)

--- a/admin-src/DiagnoseResponseForm/index.js
+++ b/admin-src/DiagnoseResponseForm/index.js
@@ -12,7 +12,26 @@ const schema = Yup.object().shape({
   answeredBy: Yup.string().required(' Required ')
 })
 
-const answerAs = ['AlFumeta', 'THCPower', '25gr', 'fernando_cannabis', 'sativa_91', 'RubenStonner', 'CRIPY', 'weedow']
+const answerAs = [
+  'AlFumeta',
+  'THCPower',
+  '25gr',
+  'fernando_cannabis',
+  'sativa_91',
+  'RubenStonner',
+  'CRIPY',
+  'weedow',
+  'ganjahman',
+  'tricoman',
+  'thegreendoctor',
+  'bluesativa',
+  'Sintabaco',
+  'paulaenverde',
+  'joseliyo',
+  'jamaica97',
+  'cannabisIndica',
+  'cogollosano'
+]
 
 export const DiagnoseResponseForm = ({ handleSubmit }) => {
   return (

--- a/admin-src/DiagnoseResponseForm/index.js
+++ b/admin-src/DiagnoseResponseForm/index.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { Formik, Form, Field, ErrorMessage } from 'formik'
+import * as Yup from 'yup'
+
+const initialValues = {
+  answer: '',
+  answeredBy: ''
+}
+
+const schema = Yup.object().shape({
+  answer: Yup.string().required(' Required '),
+  answeredBy: Yup.string().required(' Required ')
+})
+
+const answerAs = ['AlFumeta', 'THCPower', '25gr', 'fernando_cannabis', 'sativa_91', 'RubenStonner', 'CRIPY', 'weedow']
+
+export const DiagnoseResponseForm = ({ handleSubmit }) => {
+  return (
+    <Formik
+      initialValues={initialValues}
+      validationSchema={schema}
+      onSubmit={(values) => handleSubmit(values)}
+    >
+      {() => (
+        <Form>
+          <div>
+            <Field className='answer-field' component='textarea' name='answer' placeholder='answer here' />
+            <ErrorMessage name='answer' />
+          </div>
+          <div>
+            <Field name='answeredBy' component='select'>
+              <option value='' label='Answer as' />
+              {answerAs.map((user, index) => (
+                <option key={index} value={user}>{user}</option>
+              ))}
+            </Field>
+            <ErrorMessage name='answeredBy' />
+          </div>
+          <div>
+            <button type='submit'>Submit</button>
+          </div>
+        </Form>
+      )}
+    </Formik>
+  )
+}

--- a/admin-src/index.html
+++ b/admin-src/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link
+      rel="stylesheet"
+      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+      crossorigin="anonymous"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="index.js"></script>
+    </script>
+  </body>
+</html>

--- a/admin-src/index.js
+++ b/admin-src/index.js
@@ -43,7 +43,9 @@ const DiagnoseResponse = () => {
         })
 
         setDiagnoses([...unanswered])
-        setCurrentDiagnose(diagnoseOnScreen)
+        if (diagnoseOnScreen !== currentDiagnose) {
+          setCurrentDiagnose(diagnoseOnScreen)
+        }
       })
   }
 

--- a/admin-src/index.js
+++ b/admin-src/index.js
@@ -1,0 +1,67 @@
+import regeneratorRuntime from 'regenerator-runtime'
+import initFirebase from './initFirebase'
+import * as firebase from 'firebase'
+import React, { useState } from 'react'
+import ReactDOM from 'react-dom'
+import { Button, ListGroup } from 'react-bootstrap'
+import { DiagnoseResponseForm } from './DiagnoseResponseForm'
+import { DiagnoseInfo } from './DiagnoseInfo'
+import { getDownloadURLFromImages, getUnansweredDiagnoses } from './utils'
+import './stylesheets/admin.css'
+
+const DiagnoseResponse = () => {
+  const [currentDiagnose, setCurrentDiagnose] = useState(null)
+  const [diagnoses, setDiagnoses] = useState([])
+
+  const handleSubmit = async (values) => {
+    const dataToUpdate = {
+      answer: values.answer,
+      answeredBy: values.answeredBy,
+      answered: true,
+      updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+    }
+
+    await firebase.firestore().collection('diagnoses').doc(currentDiagnose.id).update(dataToUpdate)
+    setDiagnoses(diagnoses.filter(diagnose => diagnose.id !== currentDiagnose.id))
+    setCurrentDiagnose(null)
+  }
+
+  const fetchDiagnoseImagesAndSetAsCurrent = async (diagnose) => {
+    const imagesSources = await getDownloadURLFromImages(diagnose.imageReferences)
+    setCurrentDiagnose({
+      ...diagnose,
+      imagesSources
+    })
+  }
+
+  const signalFetch = async () => {
+    setDiagnoses([])
+    setCurrentDiagnose(null)
+    setDiagnoses(await getUnansweredDiagnoses())
+  }
+
+  return (
+    <>
+      <Button onClick={async () => signalFetch()}>
+        Fetch diagnoses
+      </Button>
+      <div className='row'>
+        <ListGroup className='column'>
+          {diagnoses && diagnoses.map((diagnose, index) => (
+            <ListGroup.Item action key={index} onClick={() => fetchDiagnoseImagesAndSetAsCurrent(diagnoses[index])}>
+              {diagnose.id}
+            </ListGroup.Item>
+          ))}
+        </ListGroup>
+        <div className='diagnose-info-column'>
+          {currentDiagnose && <DiagnoseInfo diagnose={currentDiagnose} />}
+        </div>
+        <div className='column'>
+          {currentDiagnose && <DiagnoseResponseForm handleSubmit={handleSubmit} />}
+        </div>
+      </div>
+    </>
+  )
+}
+
+ReactDOM.render(<DiagnoseResponse />, document.getElementById('root'))

--- a/admin-src/initFirebase.js
+++ b/admin-src/initFirebase.js
@@ -1,0 +1,13 @@
+import * as firebase from 'firebase'
+
+const firebaseConfig = {
+  apiKey: process.env.API_KEY,
+  authDomain: process.env.AUTH_DOMAIN,
+  databaseURL: process.env.DATABASE_URL,
+  projectId: process.env.PROJECT_ID,
+  storageBucket: process.env.STORAGE_BUCKET
+}
+
+if (firebase.apps.length === 0) {
+  firebase.initializeApp(firebaseConfig)
+}

--- a/admin-src/stylesheets/admin.css
+++ b/admin-src/stylesheets/admin.css
@@ -1,0 +1,21 @@
+.diagnose-image {
+  max-width: 90%;
+  height: auto;
+}
+
+.answer-field {
+  height: 200px;
+  word-wrap: break-word;
+}
+
+.row {
+  display: flex;
+}
+
+.diagnose-info-column {
+  flex:40%
+}
+
+.column {
+  flex:20%
+}

--- a/admin-src/utils/index.js
+++ b/admin-src/utils/index.js
@@ -1,0 +1,45 @@
+import * as firebase from 'firebase'
+
+const getDownloadURL = async (storageUUID) => {
+  try {
+    return await firebase.storage().ref(`images/${storageUUID}`).getDownloadURL()
+  } catch (error) {
+    console.log(error.message)
+  }
+}
+
+export const getDownloadURLFromImages = async (imageReferences) => (
+  imageReferences.reduce(
+    async (imageSources, imageStorageUUID) => {
+      imageSources = await imageSources
+      const diagnose = await getDownloadURL(imageStorageUUID)
+      imageSources.push(diagnose)
+
+      return imageSources
+    },
+    Promise.resolve([])
+  )
+)
+
+export const getUnansweredDiagnoses = async () => {
+  const unanswered = []
+
+  try {
+    const querySnapshot = await firebase
+      .firestore()
+      .collection('diagnoses')
+      .where('answered', '==', false)
+      .get()
+
+    querySnapshot.forEach(doc => {
+      unanswered.push({
+        id: doc.id,
+        ...doc.data()
+      })
+    })
+  } catch (error) {
+    console.log(error.message)
+  }
+
+  return unanswered
+}

--- a/admin-src/utils/index.js
+++ b/admin-src/utils/index.js
@@ -20,26 +20,3 @@ export const getDownloadURLFromImages = async (imageReferences) => (
     Promise.resolve([])
   )
 )
-
-export const getUnansweredDiagnoses = async () => {
-  const unanswered = []
-
-  try {
-    const querySnapshot = await firebase
-      .firestore()
-      .collection('diagnoses')
-      .where('answered', '==', false)
-      .get()
-
-    querySnapshot.forEach(doc => {
-      unanswered.push({
-        id: doc.id,
-        ...doc.data()
-      })
-    })
-  } catch (error) {
-    console.log(error.message)
-  }
-
-  return unanswered
-}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   presets: [
     'module:metro-react-native-babel-preset',
-    'module:react-native-dotenv',
+    'module:react-native-dotenv'
   ],
   plugins: [
     [

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,11 +2,6 @@ module.exports = {
   presets: [
     'module:metro-react-native-babel-preset',
     'module:react-native-dotenv',
-    '@babel/preset-env', {
-      targets: {
-        node: 'current'
-      }
-    }
   ],
   plugins: [
     [

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,12 @@
 module.exports = {
   presets: [
     'module:metro-react-native-babel-preset',
-    'module:react-native-dotenv'
+    'module:react-native-dotenv',
+    '@babel/preset-env', {
+      targets: {
+        node: 'current'
+      }
+    }
   ],
   plugins: [
     [

--- a/package.json
+++ b/package.json
@@ -7,12 +7,17 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "jest",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "admin:dev": "parcel admin-src/index.html",
+    "admin:build": "parcel build admin-src/index.html"
   },
   "dependencies": {
+    "bootstrap": "^4.3.1",
     "firebase": "^7.1.0",
     "formik": "^1.5.8",
     "react": "16.9.0",
+    "react-bootstrap": "^1.0.0-beta.14",
+    "react-dom": "^16.11.0",
     "react-native": "0.61.2",
     "react-native-dotenv": "^0.2.0",
     "react-native-gesture-handler": "^1.4.1",
@@ -33,6 +38,7 @@
     "eslint": "6.5.1",
     "jest": "24.9.0",
     "metro-react-native-babel-preset": "0.51.1",
+    "parcel-bundler": "^1.12.4",
     "react-test-renderer": "16.9.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "transformIgnorePatterns": [
       "node_modules/(?!@ngrx|(?!deck.gl)|ng-dynamic)"
     ]
-  }
+  },
+  "browserslist": [
+    "last 1 Chrome versions"
+  ]
 }


### PR DESCRIPTION
- Implemented web interface. I decided to keep this code separated from the mobile one. Its a little code repetition vs better separation of concerns, also changes in the mobile files won't affect web files.

- I did not try to deploy this using firebase hosting and, as a consequence, I do not upload public/. Also .cache/ and dist/ were heavy, so I added them to .gitignore.

- A little CSS was necessary, as the interface was too clunky to manage.

- Fetches diagnoses by the answered field.

- This is only the response feature, I consider the notification to the user a separate feature.

- I left support for multiple images, as imageReferences is determined to be an array. I manually copied Abel's cactus picture to the diagnose's image array.

- **NEW CHANGES** Fetching diagnoses now takes into consideration multiple users accessing the page, and also if someone else writes an answer. A new screencast was added to show it.


![screencast-diagnose-response-V2](https://user-images.githubusercontent.com/35865469/67882052-5b40a800-fb20-11e9-914c-11607c3d0fb4.gif)

![image](https://user-images.githubusercontent.com/35865469/67882072-64ca1000-fb20-11e9-8818-8480c62bb2da.png)


