### PR TITLE
[MP/pre-launch-styling] Changed various styles throughout the app.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,9 @@ import LoadingScreen from './screens/LoadingScreen'
 import DiagnoseRequest from './screens/MainApp/DiagnoseRequest'
 import DiagnoseResponse from './screens/MainApp/DiagnoseResponse'
 import Settings from './screens/MainApp/Settings'
+import styles from './styles'
+
+//console.disableYellowBox = true // releases only
 
 if (firebase.apps.length === 0) {
   firebase.initializeApp(firebaseConfig)
@@ -24,9 +27,9 @@ const MainApp = createBottomTabNavigator({
     screen: Home,
     navigationOptions: {
       headerTitle: 'Home',
-      tabBarLabel: 'Principal',
+      tabBarLabel: 'Diagnósticos',
       tabBarIcon: ({ tintColor }) => (
-        <Icon name='cannabis' size={22} color={tintColor} />
+        <Icon name='cannabis' size={18} color={tintColor} />
       )
     }
   },
@@ -36,7 +39,7 @@ const MainApp = createBottomTabNavigator({
       headerTitle: 'DiagnoseRequest',
       tabBarLabel: 'Diagnosticar',
       tabBarIcon: ({ tintColor }) => (
-        <Icon name='comment-medical' size={22} color={tintColor} />
+        <Icon name='comment-medical' size={18} color={tintColor} />
       )
     }
   },
@@ -44,9 +47,9 @@ const MainApp = createBottomTabNavigator({
     screen: DiagnoseResponse,
     navigationOptions: {
       headerTitle: 'DiagnoseResponse',
-      tabBarLabel: 'Diagnósticos',
+      tabBarLabel: 'Respuestas',
       tabBarIcon: ({ tintColor }) => (
-        <Icon name='microscope' size={22} color={tintColor} />
+        <Icon name='microscope' size={18} color={tintColor} />
       )
     }
   },
@@ -56,14 +59,15 @@ const MainApp = createBottomTabNavigator({
       headerTitle: 'Settings',
       tabBarLabel: 'Opciones',
       tabBarIcon: ({ tintColor }) => (
-        <Icon name='cog' size={22} color={tintColor} />
+        <Icon name='cog' size={18} color={tintColor} />
       )
     }
   }
 }, {
   tabBarOptions: {
     activeTintColor: 'green',
-    inactiveTintColor: 'gray'
+    inactiveTintColor: 'gray',
+    style: styles.tabBarStyle
   }
 })
 

--- a/src/screens/MainApp/DiagnoseResponse/Diagnose/index.js
+++ b/src/screens/MainApp/DiagnoseResponse/Diagnose/index.js
@@ -11,14 +11,14 @@ const RealThumbnailOrPlaceholder = ({ thumbnail }) => (
   />
 )
 
-const Diagnose = ({ thumbnail, answer, answeredBy }) => (
+const Diagnose = ({ thumbnail, answer, answeredBy, date, time }) => (
   <View style={styles.diagnoseContainer}>
     <RealThumbnailOrPlaceholder thumbnail={thumbnail} />
     <View style={styles.answerContainer}>
       <AppText style={styles.answeredBy}>
-        {answeredBy}
+        Respondido por {answeredBy} el {date} a las {time}
       </AppText>
-
+      <AppText style={styles.answerSeparator} />
       <AppText style={styles.answer}>
         {answer}
       </AppText>

--- a/src/screens/MainApp/DiagnoseResponse/Diagnose/styles.js
+++ b/src/screens/MainApp/DiagnoseResponse/Diagnose/styles.js
@@ -1,11 +1,12 @@
 import { StyleSheet } from 'react-native'
+import { widthPercentageToDP, heightPercentageToDP } from '~/styleMixins'
 
 const styles = StyleSheet.create({
   diagnoseContainer: {
     flex: 1,
-    width: '90%',
     flexDirection: 'row',
     padding: 10,
+    paddingBottom: 0,
     marginTop: 20,
     borderColor: 'gray',
     borderWidth: 2,
@@ -14,7 +15,7 @@ const styles = StyleSheet.create({
   },
   answerContainer: {
     marginLeft: 10,
-    width: '90%'
+    width: widthPercentageToDP('60%')
   },
   thumbnail: {
     width: 64,
@@ -24,12 +25,18 @@ const styles = StyleSheet.create({
     borderRadius: 10
   },
   answeredBy: {
+    width: widthPercentageToDP('60%'),
+    fontWeight: 'bold'
+  },
+  answerSeparator: {
     borderColor: 'gray',
     borderBottomWidth: 1,
-    width: '90%'
+    bottom: heightPercentageToDP('2%')
   },
   answer: {
-    width: '90%'
+    width: widthPercentageToDP('70%'),
+    paddingRight: widthPercentageToDP('10%'),
+    bottom: heightPercentageToDP('2%')
   }
 })
 

--- a/src/screens/MainApp/DiagnoseResponse/NoAnswersYet/index.js
+++ b/src/screens/MainApp/DiagnoseResponse/NoAnswersYet/index.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { View } from 'react-native'
+import AppText from '~/helpers/AppText'
+import styles from './styles'
+
+const NoAnswersYet = () => (
+  <View>
+    <AppText style={styles.noAnswersText}>Todavía no hay respuestas :(</AppText>
+  </View>
+)
+
+export default NoAnswersYet

--- a/src/screens/MainApp/DiagnoseResponse/NoAnswersYet/styles.js
+++ b/src/screens/MainApp/DiagnoseResponse/NoAnswersYet/styles.js
@@ -1,0 +1,10 @@
+import { StyleSheet } from 'react-native'
+
+const styles = StyleSheet.create({
+  noAnswersText: {
+    color: 'gray',
+    fontSize: 18
+  }
+})
+
+export default styles

--- a/src/screens/MainApp/DiagnoseResponse/styles.js
+++ b/src/screens/MainApp/DiagnoseResponse/styles.js
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native'
+import { heightPercentageToDP } from '~/styleMixins'
 
 const styles = StyleSheet.create({
   container: {
@@ -7,6 +8,11 @@ const styles = StyleSheet.create({
   },
   downloadingIndicator: {
     margin: 5
+  },
+  noAnswersYetContainer: {
+    flex: 1,
+    alignItems: 'center',
+    top: heightPercentageToDP('40%')
   }
 })
 

--- a/src/screens/MainApp/DiagnoseResponse/utils/index.js
+++ b/src/screens/MainApp/DiagnoseResponse/utils/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import moment from 'moment'
 import Diagnose from '../Diagnose'
 import * as DatabaseService from '~/databaseService'
 import * as StorageService from '~/storageService'
@@ -26,11 +27,14 @@ export const getDiagnosesFromAnswers = async (answers) => (
 
 const getDiagnoseFromAnswer = async (answer, key) => {
   const thumbnail = await getURL(answer.imageReferences[0])
+  const date = moment(answer.updatedAt.seconds * 1000)
   return (
     <Diagnose key={key}
       thumbnail={thumbnail}
       answeredBy={answer.answeredBy}
       answer={answer.answer}
+      date={date.format('DD/MM/YYYY')}
+      time={date.format('hh:mm a')}
     />
   )
 }
@@ -43,6 +47,10 @@ const getURL = async (imageReference) => {
   }
 }
 
-export const sortByCreatedAt = (answers) => (
-  answers.sort((a, b) => a.createdAt - b.createdAt)
+export const sortAnswersByMostRecentCreation = (answers) => (
+  answers.sort((a, b) => b.createdAt.toMillis() - a.createdAt.toMillis())
+)
+
+export const sortAnswersByMostRecentUpdate = (answers) => (
+  answers.sort((a, b) => b.updatedAt.toMillis() - a.updatedAt.toMillis())
 )

--- a/src/screens/MainApp/Home/Dashboard/DiagnosesBoard/BoardItem/index.js
+++ b/src/screens/MainApp/Home/Dashboard/DiagnosesBoard/BoardItem/index.js
@@ -29,15 +29,15 @@ const BoardItem = ({ thumbnail, diagnose }) => {
         <RealThumbnailOrPlaceholder thumbnail={thumbnail} />
       </View>
       <View style={styles.body}>
-        <View style={styles.title}>
-          <AppText style={styles.titleText}>DESCRIPCIÓN</AppText>
-          <View>
+        <View style={styles.diagnoseStateContainer}>
+          <View style={styles.dateContainer}>
             <AppText style={styles.titleDate}>{date.format('DD/MM/YYYY')}</AppText>
+            <AppText style={styles.titleDate}>-</AppText>
             <AppText style={styles.titleDate}>{date.format('hh:mm a')}</AppText>
           </View>
           <AnsweredIcon answered={diagnose.answered} />
         </View>
-        <View>
+        <View style={styles.problemInfo}>
           <AppText>{diagnose.text}</AppText>
         </View>
       </View>

--- a/src/screens/MainApp/Home/Dashboard/DiagnosesBoard/BoardItem/styles.js
+++ b/src/screens/MainApp/Home/Dashboard/DiagnosesBoard/BoardItem/styles.js
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native'
+import { widthPercentageToDP } from '~/styleMixins'
 
 const styles = StyleSheet.create({
   container: {
@@ -21,15 +22,22 @@ const styles = StyleSheet.create({
   body: {
     padding: 6
   },
-  title: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
+  problemInfo: {
     paddingBottom: 5,
     paddingTop: 3
   },
+  diagnoseStateContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center'
+  },
+  dateContainer: {
+    flexDirection: 'row'
+  },
   titleDate: {
     textAlign: 'right',
-    fontSize: 12
+    alignSelf: 'center',
+    fontSize: 12,
+    margin: widthPercentageToDP('1%')
   },
   answered: {
     maxHeight: 30,
@@ -40,13 +48,6 @@ const styles = StyleSheet.create({
     maxHeight: 30,
     maxWidth: 30,
     marginLeft: 5
-  },
-  titleText: {
-    flex: 1,
-    fontSize: 18,
-    textAlignVertical: 'center',
-    fontWeight: 'bold',
-    color: '#000000'
   }
 })
 

--- a/src/screens/MainApp/Home/Dashboard/DiagnosesBoard/index.js
+++ b/src/screens/MainApp/Home/Dashboard/DiagnosesBoard/index.js
@@ -40,8 +40,8 @@ const getBoardItemFromDiagnose = async (diagnose, key) => {
   )
 }
 
-const sortByCreatedAt = (diagnoses) => (
-  diagnoses.sort((a, b) => a.createdAt - b.createdAt)
+const sortDiagnosesByMostRecentCreation = (Diagnoses) => (
+  Diagnoses.sort((a, b) => b.createdAt.toMillis() - a.createdAt.toMillis())
 )
 
 const DiagnosesBoard = () => {
@@ -59,7 +59,7 @@ const DiagnosesBoard = () => {
     setDownloadingDiagnoses(true)
     try {
       const downloadedData = await getDiagnosesFromCurrentUser()
-      const sortedData = sortByCreatedAt(downloadedData)
+      const sortedData = sortDiagnosesByMostRecentCreation(downloadedData)
       const diagnoses = await buildBoardItems(sortedData)
       setDiagnoses(diagnoses)
     } catch (error) {
@@ -75,7 +75,7 @@ const DiagnosesBoard = () => {
   return (
     <View style={styles.container}>
       <AppText style={styles.title}>
-        Diagnósticos pendientes
+        Diagnósticos
       </AppText>
       <View style={styles.listContainer}>
         {downloadingDiagnoses && <ActivityIndicator style={styles.downloadingIndicator} />}

--- a/src/screens/MainApp/Home/index.js
+++ b/src/screens/MainApp/Home/index.js
@@ -2,7 +2,6 @@ import React from 'react'
 import DashBoard from './Dashboard'
 import * as AnalyticsService from '~/analyticsService'
 
-
 const Home = () => {
   AnalyticsService.setCurrentScreenName('Home')
   return (

--- a/src/screens/authentication/Login/LoginForm/styles.js
+++ b/src/screens/authentication/Login/LoginForm/styles.js
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native'
+import { heightPercentageToDP, widthPercentageToDP } from '~/styleMixins'
 
 const styles = StyleSheet.create({
   loginError: {
@@ -6,13 +7,13 @@ const styles = StyleSheet.create({
     color: 'white'
   },
   loginForm: {
-    width: '75%',
-    margin: '25%'
+    width: widthPercentageToDP('75%'),
+    margin: heightPercentageToDP('15%')
   },
   loginButton: {
     backgroundColor: 'rgba(92, 254, 78, 0.71)',
     borderRadius: 40,
-    margin: 30,
+    margin: heightPercentageToDP('5%'),
     padding: 10,
     alignSelf: 'center'
   },
@@ -24,7 +25,8 @@ const styles = StyleSheet.create({
     color: 'white'
   },
   label: {
-    margin: 13,
+    margin: heightPercentageToDP('1'),
+    padding: heightPercentageToDP('1'),
     paddingLeft: 15,
     backgroundColor: 'rgba(254,93,78, 0.8)',
     color: 'white',

--- a/src/screens/authentication/Login/LoginHeader/styles.js
+++ b/src/screens/authentication/Login/LoginHeader/styles.js
@@ -1,17 +1,18 @@
 import { StyleSheet } from 'react-native'
+import { heightPercentageToDP, widthPercentageToDP } from '~/styleMixins'
 
 const styles = StyleSheet.create({
   loginImage: {
     width: 163,
     height: 163,
-    top: '10%',
+    top: heightPercentageToDP('10%'),
     right: 10
   },
   loginText: {
     color: 'white',
     fontSize: 18,
-    top: '15%',
-    right: '25%'
+    top: heightPercentageToDP('15%'),
+    right: widthPercentageToDP('25%')
   }
 })
 

--- a/src/screens/authentication/Login/NoAccountLink/styles.js
+++ b/src/screens/authentication/Login/NoAccountLink/styles.js
@@ -1,9 +1,10 @@
 import { StyleSheet } from 'react-native'
+import { heightPercentageToDP } from '~/styleMixins'
 
 const styles = StyleSheet.create({
   noAccountText: {
     color: 'white',
-    bottom: '10%'
+    bottom: heightPercentageToDP('10')
   },
   underlineText: {
     textDecorationLine: 'underline'

--- a/src/screens/authentication/SignUp/AccountLink/styles.js
+++ b/src/screens/authentication/SignUp/AccountLink/styles.js
@@ -1,9 +1,10 @@
 import { StyleSheet } from 'react-native'
+import { heightPercentageToDP } from '~/styleMixins'
 
 const styles = StyleSheet.create({
   accountText: {
     color: 'white',
-    bottom: '15%'
+    bottom: heightPercentageToDP('15')
   },
   underlineText: {
     textDecorationLine: 'underline'

--- a/src/screens/authentication/SignUp/SignUpForm/styles.js
+++ b/src/screens/authentication/SignUp/SignUpForm/styles.js
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native'
+import { heightPercentageToDP, widthPercentageToDP } from '~/styleMixins'
 
 const styles = StyleSheet.create({
   signUpError: {
@@ -6,13 +7,13 @@ const styles = StyleSheet.create({
     color: 'white'
   },
   signUpForm: {
-    width: '75%',
-    margin: '25%'
+    width: widthPercentageToDP('75%'),
+    margin: heightPercentageToDP('15%')
   },
   signUpButton: {
     backgroundColor: 'rgba(92, 254, 78, 0.71)',
     borderRadius: 40,
-    margin: 30,
+    margin: heightPercentageToDP('5%'),
     padding: 10,
     alignSelf: 'center'
   },
@@ -24,7 +25,8 @@ const styles = StyleSheet.create({
     color: 'white'
   },
   label: {
-    margin: 13,
+    margin: heightPercentageToDP('1'),
+    padding: heightPercentageToDP('1'),
     paddingLeft: 15,
     backgroundColor: 'rgba(254,93,78, 0.8)',
     color: 'white',

--- a/src/screens/authentication/SignUp/SignUpHeader/styles.js
+++ b/src/screens/authentication/SignUp/SignUpHeader/styles.js
@@ -1,16 +1,17 @@
 import { StyleSheet } from 'react-native'
+import { heightPercentageToDP, widthPercentageToDP } from '~/styleMixins'
 
 const styles = StyleSheet.create({
   signUpImage: {
     width: 163,
     height: 163,
-    top: '15%'
+    top: heightPercentageToDP('15%')
   },
   signUpText: {
     color: 'white',
     fontSize: 18,
-    top: '15%',
-    right: '25%'
+    top: heightPercentageToDP('15%'),
+    right: widthPercentageToDP('25%')
   }
 })
 

--- a/src/styleMixins/index.js
+++ b/src/styleMixins/index.js
@@ -1,0 +1,15 @@
+import { Dimensions, PixelRatio } from 'react-native'
+
+export const widthPercentageToDP = widthPercent => {
+  const screenWidth = Dimensions.get('window').width
+  const elemWidth = parseFloat(widthPercent)
+
+  return PixelRatio.roundToNearestPixel(screenWidth * elemWidth / 100)
+}
+
+export const heightPercentageToDP = heightPercent => {
+  const screenHeight = Dimensions.get('window').height
+  const elemHeight = parseFloat(heightPercent)
+
+  return PixelRatio.roundToNearestPixel(screenHeight * elemHeight / 100)
+}

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,0 +1,10 @@
+import { StyleSheet } from 'react-native'
+
+const styles = StyleSheet.create({
+  tabBarStyle: {
+    paddingTop: 5,
+    paddingBottom: 5
+  }
+})
+
+export default styles


### PR DESCRIPTION
- Basically solved Trello's card points.

- Added a styleMixins file which has functions to calculate pixel density based on device height and width. Classic width and height percentages refers to the immediate parent component, so in some devices it caused bad rendering (there are occasions though when you want the width and height percentage to be relative to it's parent component)

- Also added an instruction for releases to disable warnings and such, so that the one who compiles for production can toggle it on and off (you can force a warning by doing some specific sequence of actions, signaling a component to be unmounted from the component tree, but still having pending state to be changed due to asynchronous operations) This is a problem regarding react-tab-navigation, which doesn't unmount components, and react-switch-navigation which does unmount them. A will probably document this behavior.

**Removed "pendientes", removed "descripcion" (I had to put some styling to cover it's space). Fixed sorting on both diagnoseBoard and diagnoseResponse**

![image](https://user-images.githubusercontent.com/35865469/68152971-6f6f1580-ff23-11e9-960e-b4f9985fb485.png)


**padding on tab**

![image](https://user-images.githubusercontent.com/35865469/68153011-89105d00-ff23-11e9-98e7-e7bf87860b1f.png)


**More info on responses (date is based on updatedAt field)**

![image](https://user-images.githubusercontent.com/35865469/68152520-9711ae00-ff22-11e9-9c93-b8caf181b91c.png)

**Disclaimer when no diagnose was answered**

![image](https://user-images.githubusercontent.com/35865469/68152620-c6c0b600-ff22-11e9-9c4f-2f89f1bb9b95.png)





