### PR TITLE
[MP] Show-username-in-web-interface

### DIFF
--- a/admin-src/DiagnoseInfo/index.js
+++ b/admin-src/DiagnoseInfo/index.js
@@ -6,7 +6,7 @@ export const DiagnoseInfo = ({ diagnose }) => (
       DIAGNOSE UUID: {diagnose.id}
     </div>
     <div>
-      USER UUID: {diagnose.user}
+      USERNAME: {diagnose.username}
     </div>
     <div>
       TEXT: {diagnose.text}

--- a/admin-src/index.js
+++ b/admin-src/index.js
@@ -20,7 +20,6 @@ const DiagnoseResponse = () => {
         .where('answered', '==', false)
         .onSnapshot(async (querySnapshot) => {
           let unanswered = diagnoses
-          let diagnoseOnScreen = currentDiagnose
 
           await Promise.all(
             querySnapshot.docChanges().map(async docChange => {
@@ -42,20 +41,30 @@ const DiagnoseResponse = () => {
 
               if (changeType === 'removed') {
                 unanswered = unanswered.filter(diagnose => diagnose.id !== doc.id)
-                if (diagnoseOnScreen && diagnoseOnScreen.id === doc.id) {
-                  diagnoseOnScreen = null
-                }
               }
             })
           )
 
           setDiagnoses([...unanswered])
-          setCurrentDiagnose(diagnoseOnScreen)
         })
     }
 
     attachQueryListenerForUnansweredDiagnoses()
   }, [])
+
+  useEffect(() => {
+    const clearScreenIfCurrentDiagnoseWasAnsweredByAnotherOne = () => {
+      if (currentDiagnose) {
+        const queryForCurrentDiagnoseInDiagnoses = diagnoses.filter(diagnose => diagnose.id === currentDiagnose.id)
+        const currentDiagnoseDoesNotExist = queryForCurrentDiagnoseInDiagnoses.length === 0
+        if (currentDiagnoseDoesNotExist) {
+          setCurrentDiagnose(null)
+        }
+      }
+    }
+
+    clearScreenIfCurrentDiagnoseWasAnsweredByAnotherOne()
+  }, [diagnoses])
 
   const handleSubmit = async (values) => {
     const dataToUpdate = {


### PR DESCRIPTION
- Added usernames to the locations suggested by @abelosorio 

- Fetching usernames induces more access to the database.

- Moved clearing screen (if someone else just happens to answers the same screen as you are viewing) to a separate useEffect hook.

![image](https://user-images.githubusercontent.com/35865469/68412707-75573780-016b-11ea-9a04-3f5a8f149560.png)

