### PR TITLE
[MP/Adding-theme-support-and-reusable-components]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ node_modules
 .nvm
 /bots/node_modules/
 package-lock.json
+yarn.lock
 
 # OS X
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "firebase": "^7.1.0",
     "formik": "^1.5.8",
     "moment": "^2.24.0",
+    "prop-types": "^15.7.2",
     "react": "16.9.0",
     "react-bootstrap": "^1.0.0-beta.14",
     "react-dom": "^16.11.0",

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -33,7 +33,8 @@ const styles = StyleSheet.create({
     height: theme.sizes.base,
     justifyContent: 'center',
     alignItems: 'center',
-    marginVertical: theme.sizes.padding
+    margin: theme.sizes.margin,
+    padding: theme.sizes.padding
   },
 
   primary: { backgroundColor: theme.colors.primary },
@@ -42,12 +43,13 @@ const styles = StyleSheet.create({
   white: { backgroundColor: theme.colors.white },
   gray: { backgroundColor: theme.colors.gray },
   gray2: { backgroundColor: theme.colors.gray2 },
-  gray3: { backgroundColor: theme.colors.gray3 }
+  gray3: { backgroundColor: theme.colors.gray3 },
+  alpha: { backgroundColor: theme.colors.alpha }
 })
 
 Button.propTypes = {
   style: PropTypes.object,
-  variant: PropTypes.oneOf(['primary', 'secondary', 'black', 'white', 'gray', 'gray2', 'gray3'])
+  variant: PropTypes.oneOf(['primary', 'secondary', 'black', 'white', 'gray', 'gray2', 'gray3', 'alpha'])
 }
 
 Button.defaultProps = {

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import { TouchableOpacity, StyleSheet } from 'react-native'
+import PropTypes from 'prop-types'
+import { theme } from '~/constants'
+
+const Button = (props) => {
+  const {
+    style,
+    variant,
+    children,
+    ...restProps
+  } = props
+
+  const buttonStyles = [
+    styles.button,
+    variant && styles[variant],
+    style // this is the last applied style, which can overwrite the others
+  ]
+
+  return (
+    <TouchableOpacity
+      style={buttonStyles}
+      {...restProps}
+    >
+      {children}
+    </TouchableOpacity>
+  )
+}
+
+const styles = StyleSheet.create({
+  button: {
+    borderRadius: theme.sizes.border,
+    height: theme.sizes.base,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginVertical: theme.sizes.padding
+  },
+
+  primary: { backgroundColor: theme.colors.primary },
+  secondary: { backgroundColor: theme.colors.secondary },
+  black: { backgroundColor: theme.colors.black },
+  white: { backgroundColor: theme.colors.white },
+  gray: { backgroundColor: theme.colors.gray },
+  gray2: { backgroundColor: theme.colors.gray2 },
+  gray3: { backgroundColor: theme.colors.gray3 }
+})
+
+Button.propTypes = {
+  style: PropTypes.object,
+  variant: PropTypes.oneOf(['primary', 'secondary', 'black', 'white', 'gray', 'gray2', 'gray3'])
+}
+
+Button.defaultProps = {
+  variant: 'primary'
+}
+
+export default Button

--- a/src/components/Text/index.js
+++ b/src/components/Text/index.js
@@ -55,7 +55,7 @@ Text.propTypes = {
 }
 
 Text.defaultProps = {
-  colorVariant: 'black',
+  colorVariant: 'white',
   fontVariant: 'body'
 }
 

--- a/src/components/Text/index.js
+++ b/src/components/Text/index.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import { Text as ReactText, StyleSheet } from 'react-native'
+import PropTypes from 'prop-types'
+import { theme } from '~/constants'
+
+const Text = (props) => {
+  const {
+    style,
+    colorVariant,
+    fontVariant,
+    children,
+    ...restProps
+  } = props
+
+  const textStyles = [
+    styles.text,
+    colorVariant && styles[colorVariant],
+    fontVariant && styles[fontVariant],
+    style // this is the last applied style, which can overwrite the others
+  ]
+
+  return (
+    <ReactText style={textStyles} {...restProps}>
+      {children}
+    </ReactText>
+  )
+}
+
+const styles = StyleSheet.create({
+  text: {
+    fontSize: theme.sizes.font,
+    color: theme.colors.black
+  },
+
+  h1: { ...theme.fonts.h1 },
+  h2: { ...theme.fonts.h2 },
+  h3: { ...theme.fonts.h3 },
+  description: { ...theme.fonts.description },
+  body: { ...theme.fonts.body },
+  date: { ...theme.fonts.date },
+
+  primary: { color: theme.colors.primary },
+  secondary: { color: theme.colors.secondary },
+  black: { color: theme.colors.black },
+  white: { color: theme.colors.white },
+  gray: { color: theme.colors.gray },
+  gray2: { color: theme.colors.gray2 },
+  gray3: { color: theme.colors.gray3 }
+})
+
+Text.propTypes = {
+  style: PropTypes.object,
+  colorVariant: PropTypes.oneOf(['primary', 'secondary', 'black', 'white', 'gray', 'gray2', 'gray3']),
+  fontVariant: PropTypes.oneOf(['h1', 'h2', 'h3', 'description', 'body', 'date'])
+}
+
+Text.defaultProps = {
+  colorVariant: 'black',
+  fontVariant: 'body'
+}
+
+export default Text

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,2 @@
+export { default as Text } from './Text'
+export { default as Button } from './Button'

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,5 @@
+import * as theme from './theme'
+
+export {
+  theme
+}

--- a/src/constants/theme.js
+++ b/src/constants/theme.js
@@ -7,7 +7,8 @@ const colors = {
   white: '#FFFFFF',
   gray: '#BDBFC7',
   gray2: '#D8D8D8',
-  gray3: '#F0F0F0'
+  gray3: '#F0F0F0',
+  alpha: 'rgba(255, 255, 255, 0.01)'
 }
 
 const sizes = {

--- a/src/constants/theme.js
+++ b/src/constants/theme.js
@@ -1,0 +1,63 @@
+import { scale, verticalScale, moderateScale } from 'react-native-size-matters'
+
+const colors = {
+  primary: 'rgba(92, 254, 78, 0.71)',
+  secondary: 'rgba(254,93,78, 0.8)',
+  black: '#2F2F2F',
+  white: '#FFFFFF',
+  gray: '#BDBFC7',
+  gray2: '#D8D8D8',
+  gray3: '#F0F0F0'
+}
+
+const sizes = {
+  // global sizes
+  base: moderateScale(20),
+  font: moderateScale(14),
+  border: moderateScale(30),
+  padding: moderateScale(10),
+  margin: moderateScale(15),
+
+  // font sizes
+  h1: moderateScale(22),
+  h2: moderateScale(18),
+  h3: moderateScale(16),
+  description: moderateScale(18),
+  body: moderateScale(14),
+  date: moderateScale(12)
+}
+
+const fonts = {
+  h1: {
+    fontFamily: 'Roboto',
+    fontSize: sizes.h1,
+    fontWeight: 'bold'
+  },
+  h2: {
+    fontFamily: 'Roboto',
+    fontSize: sizes.h2,
+    fontWeight: 'bold'
+  },
+  h3: {
+    fontFamily: 'Roboto',
+    fontSize: sizes.h3,
+    fontWeight: 'bold'
+  },
+  description: {
+    fontFamily: 'Roboto',
+    fontSize: sizes.description,
+    fontWeight: 'normal'
+  },
+  body: {
+    fontFamily: 'Roboto',
+    fontSize: sizes.body,
+    fontWeight: 'normal'
+  },
+  date: {
+    fontFamily: 'Roboto',
+    fontSize: sizes.date,
+    fontWeight: '500'
+  }
+}
+
+export { colors, sizes, fonts }


### PR DESCRIPTION
- Added theme.js, which encapsulates colors, sizes and fonts.

- Added Text and Button generic components. They accept props for automatic styling based on theme, they are also customizable (you can manually apply new styles and overwrite the theme ones should we need that). This Text replaces AppText (this new one is more flexible).

- restProps pattern is used, so this Text and Button has the same interface as react-native Text and TouchableOpacity

Sample usage

![image](https://user-images.githubusercontent.com/35865469/70475404-34787880-1ab3-11ea-8bb8-6a217615b029.png)

Default props are those with more common usage. Proptypes added to enforce specific values.