### PR TITLE
[MP] Refactor-loading-screen-with-theme

### DIFF
--- a/src/screens/LoadingScreen/index.js
+++ b/src/screens/LoadingScreen/index.js
@@ -5,7 +5,7 @@ import NavigationService from '~/navigationService'
 import * as AnalyticsService from '~/analyticsService'
 import * as CacheService from '~/cacheService'
 import Background from '~/helpers/Background'
-import AppText from '~/helpers/AppText'
+import { Text } from '~/components'
 import DrCannabis from '~/assets/images/DrCannabis.png'
 import styles from './styles'
 
@@ -44,7 +44,7 @@ const LoadingScreen = () => {
           style={styles.DrCannabisIcon}
           source={DrCannabis}
         />
-        <AppText style={styles.DrCannabisText}>Dr. Cannabis</AppText>
+        <Text fontVariant='h1' colorVariant='primary' style={styles.DrCannabisText}>Dr. Cannabis</Text>
       </View>
     </Background>
   )

--- a/src/screens/LoadingScreen/styles.js
+++ b/src/screens/LoadingScreen/styles.js
@@ -1,8 +1,9 @@
 import { StyleSheet } from 'react-native'
 import { scale, verticalScale } from 'react-native-size-matters'
+import { theme } from '~/constants'
 
 const baseMarginVertical = {
-  marginVertical: verticalScale(5)
+  marginVertical: theme.sizes.margin / 3
 }
 
 const styles = StyleSheet.create({
@@ -17,9 +18,7 @@ const styles = StyleSheet.create({
     ...baseMarginVertical
   },
   DrCannabisText: {
-    color: 'rgba(92, 254, 78, 0.71)',
     fontSize: scale(30),
-    fontWeight: 'bold',
     ...baseMarginVertical
   }
 


### PR DESCRIPTION
- I left `fontSize: scale(30)` on Dr Cannabis due to it being different to the guidelines (it needs to be big but it's just too big to be a header/title)