### PR TITLE
MP/ Add script to set amountOfAnswers for existing answered requests

### DIFF
--- a/scripts/setAmountOfAnswersInExistingAnsweredRequests.js
+++ b/scripts/setAmountOfAnswersInExistingAnsweredRequests.js
@@ -15,8 +15,14 @@ const setAmountOfAnswersInExistingAnsweredRequests = async () => {
     await Promise.all(
       snapshots.docs.map(async (doc) => {
         console.log(`Setting amount of answers for ${doc.id}`)
+
+        const responses = await admin
+          .firestore()
+          .collection(`users/${doc.ref.parent.parent.id}/requests/${doc.id}/responses`)
+          .get()
+
         await doc.ref.update({
-          amountOfAnswers: 1
+          amountOfAnswers: responses.docs.length
         })
       })
     )

--- a/scripts/setAmountOfAnswersInExistingAnsweredRequests.js
+++ b/scripts/setAmountOfAnswersInExistingAnsweredRequests.js
@@ -1,0 +1,30 @@
+const admin = require('firebase-admin')
+const { initFirebaseAdmin } = require('./utils/initFirebaseAdmin.js')
+
+initFirebaseAdmin()
+
+const setAmountOfAnswersInExistingAnsweredRequests = async () => {
+  try {
+    const answeredRequests = admin
+      .firestore()
+      .collectionGroup('requests')
+      .where('answered', '==', true)
+
+    const snapshots = await answeredRequests.get()
+
+    await Promise.all(
+      snapshots.docs.map(async (doc) => {
+        console.log(`Setting amount of answers for ${doc.id}`)
+        await doc.ref.update({
+          amountOfAnswers: 1
+        })
+      })
+    )
+  } catch (error) {
+    console.error(error.message)
+  }
+}
+
+setAmountOfAnswersInExistingAnsweredRequests()
+  .then()
+  .catch(console.error.bind(console))

--- a/scripts/setAmountOfAnswersInExistingAnsweredRequests.js
+++ b/scripts/setAmountOfAnswersInExistingAnsweredRequests.js
@@ -8,22 +8,28 @@ const setAmountOfAnswersInExistingAnsweredRequests = async () => {
     const answeredRequests = admin
       .firestore()
       .collectionGroup('requests')
-      .where('answered', '==', true)
 
     const snapshots = await answeredRequests.get()
 
     await Promise.all(
       snapshots.docs.map(async (doc) => {
         console.log(`Setting amount of answers for ${doc.id}`)
+        const { answered, ...data } = doc.data()
 
-        const responses = await admin
-          .firestore()
-          .collection(`users/${doc.ref.parent.parent.id}/requests/${doc.id}/responses`)
-          .get()
+        if (answered) {
+          const responses = await admin
+            .firestore()
+            .collection(`users/${doc.ref.parent.parent.id}/requests/${doc.id}/responses`)
+            .get()
 
-        await doc.ref.update({
-          amountOfAnswers: responses.docs.length
-        })
+          await doc.ref.update({
+            amountOfAnswers: responses.docs.length
+          })
+        } else {
+          await doc.ref.update({
+            amountOfAnswers: 0
+          })
+        }
       })
     )
   } catch (error) {


### PR DESCRIPTION
- This uses collectionGroup queries, every document inside a subcollection 'requests' enters the query and gets filtered if it has an 'answered' field set as true. For each on of those, the amountOfAnswers is set to have a value of 1.

- **A new composite index is needed for this, executing this script without setting up the index will fail execution and show the link to set up the index in console**

![image](https://user-images.githubusercontent.com/35865469/73026303-ec69a700-3e0f-11ea-9cc2-01ebcd3a9197.png)

- **To run this script, refer to documentation regarding setup and execution for scripts**
