### PR TITLE
MP/ Add jsconfig file to solve VSCode pathing problems

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"]
+    }
+  }
+}


### PR DESCRIPTION
VSCode has a pathing problem when using `babel-plugin-root-import`, it doesn't know how to solve these paths, as it has no knowledge of the suffix `~`.  This solves that problem and lets you change a name of a folder/file and have it updated throughout the project.